### PR TITLE
Non-op functionality

### DIFF
--- a/pack/data/pack/functions/tpend.mcfunction
+++ b/pack/data/pack/functions/tpend.mcfunction
@@ -1,1 +1,3 @@
 execute if entity @s[gamemode=spectator] run execute in minecraft:the_end run tp @s 100 49 0
+scoreboard players reset @s tpend
+scoreboard players enable @s tpend

--- a/pack/data/pack/functions/tpoverworld.mcfunction
+++ b/pack/data/pack/functions/tpoverworld.mcfunction
@@ -1,1 +1,3 @@
 execute if entity @s[gamemode=spectator] run execute in minecraft:overworld run tp @s 0 100 0
+scoreboard players reset @s tpoverworld
+scoreboard players enable @s tpoverworld

--- a/pack/data/pack/functions/triggercheck.mcfunction
+++ b/pack/data/pack/functions/triggercheck.mcfunction
@@ -1,2 +1,2 @@
-execute as @a[scores={tpend=1..}] at @s run function pack:tpoverworld
+execute as @a[scores={tpend=1..}] at @s run function pack:tpend
 execute as @a[scores={tpoverworld=1..}] at @s run function pack:tpoverworld

--- a/pack/data/pack/functions/triggercheck.mcfunction
+++ b/pack/data/pack/functions/triggercheck.mcfunction
@@ -1,0 +1,2 @@
+execute as @a[scores={tpend=1..}] at @s run function pack:tpoverworld
+execute as @a[scores={tpoverworld=1..}] at @s run function pack:tpoverworld


### PR DESCRIPTION
# Description

Implemented feature to make this pack usable by non-operators. People can now use `/trigger tpend` and `/trigger tpoverworld` to use the functions.

Fixes #3 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on a server.

**Test Configuration**:
* Minecraft version: 1.16.4
* Mods loader: n/a
* Mods: n/a
